### PR TITLE
Refine quadrant storage with dynamic bucket helpers

### DIFF
--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,6 +1,6 @@
-import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
+import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
-import { idbGet, idbPut } from './SDFGridStorage.js';
+import { idbGet, idbPut, loadQuadrantRecord, persistQuadrantRecord } from './SDFGridStorage.js';
 import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
 
 function _quadrantLayout(count){
@@ -121,43 +121,71 @@ export async function _ensureDenseLayer(z){
 
   const targetSchema=this.schema;
   const Fnew=targetSchema.fieldNames.length;
-  const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  _ensureLayout(this);
 
   if (!this._db){
     const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
     this._layerCache.set(key,arr); return arr;
   }
 
+  const template=await this._ensureZeroTemplate();
+  let qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
+  const quadTemplate=template?.quadrants;
+  if (Array.isArray(quadTemplate) && quadTemplate.length){
+    qCount=quadTemplate.length;
+    if (this.quadrantCount !== qCount){
+      this.quadrantCount=qCount;
+      this._quadLayout=null;
+    }
+  }
+  _ensureLayout(this);
+
   const lmeta=await idbGet(this._db, STORE_LMETA, key);
-  const buffers=await Promise.all(Array.from({length:qCount},(_,i)=>idbGet(this._db, STORE_LAYER, `${key},${i}`)));
+  const buffers=new Array(qCount);
+  const missing=[];
+  for (let qi=0; qi<qCount; qi++){
+    const rec=await loadQuadrantRecord(this._db, key, qi);
+    if (rec?.buffer) buffers[qi]=rec.buffer;
+    else missing.push(qi);
+  }
 
   if (buffers.every(b=>!b)){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
+    const arr=denseFromQuadrants(template, targetSchema);
     await this._applySparseIntoDense(z, arr);
-    await Promise.all(Array.from({length:qCount},(_,i)=>{
-      const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-      return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-    }));
+    for (let qi=0; qi<qCount; qi++){
+      const quad=_sliceQuadrant.call(this, arr, qi, Fnew);
+      await persistQuadrantRecord(this._db, key, qi, quad);
+    }
     await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
     this._layerCache.set(key,arr); return arr;
   }
 
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
-  if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
-    for(let i=0;i<qCount;i++){
-      const buf=buffers[i]; if(!buf) continue;
-      _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
+  const schemaMatches = curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames);
+
+  if (schemaMatches){
+    const needsTemplate = missing.length>0;
+    const arr=needsTemplate ? denseFromQuadrants(template, targetSchema) : new Float32Array(DENSE_W*DENSE_H*Fnew);
+
+    for (let qi=0; qi<qCount; qi++){
+      const buf=buffers[qi]; if(!buf) continue;
+      _insertQuadrant.call(this, arr, qi, new Float32Array(buf), Fnew);
     }
+
+    if (needsTemplate){
+      for (const qi of missing){
+        const quad=_sliceQuadrant.call(this, arr, qi, Fnew);
+        await persistQuadrantRecord(this._db, key, qi, quad);
+      }
+      await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
+    }
+
     this._layerCache.set(key,arr); return arr;
   }
 
   const Fold=curList.length;
   const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-  const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+  const arr=denseFromQuadrants(template, targetSchema);
 
   for(let qi=0; qi<qCount; qi++){
     const buf=buffers[qi]; if(!buf) continue;
@@ -183,10 +211,10 @@ export async function _ensureDenseLayer(z){
     }
   }
 
-  await Promise.all(Array.from({length:qCount},(_,i)=>{
-    const quad=_sliceQuadrant.call(this, arr, i, Fnew);
-    return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
-  }));
+  for (let qi=0; qi<qCount; qi++){
+    const quad=_sliceQuadrant.call(this, arr, qi, Fnew);
+    await persistQuadrantRecord(this._db, key, qi, quad);
+  }
   await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
   this._layerCache.set(key,arr); return arr;
 }
@@ -273,12 +301,12 @@ export async function _flushDirtyLayers(){
     const arr=this._layerCache.get(z|0);
     if (!arr) return;
     const F=this.schema.fieldNames.length;
-    const writes=Array.from(set).map(qi=>{
+    const ordered=Array.from(set).sort((a,b)=>a-b);
+    for (const qi of ordered){
       const quad=_sliceQuadrant.call(this, arr, qi, F);
-      return idbPut(this._db, STORE_LAYER, `${z},${qi}`, quad.buffer);
-    });
-    writes.push(idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames }));
-    await Promise.all(writes);
+      await persistQuadrantRecord(this._db, z|0, qi, quad);
+    }
+    await idbPut(this._db, STORE_LMETA, z|0, { sid:this.schema.id, fields:this.schema.fieldNames });
   }));
   this._flushHandle=null;
 }

--- a/SDFGridStorage.js
+++ b/SDFGridStorage.js
@@ -35,3 +35,73 @@ export function idbPut(db,store,key,val){
     const rq=st.put(val,key); rq.onsuccess=()=>res(true); rq.onerror=()=>rej(rq.error);
   });
 }
+
+export function idbDelete(db,store,key){
+  return new Promise((res,rej)=>{
+    const tx=db.transaction(store,'readwrite'), st=tx.objectStore(store);
+    const rq=st.delete(key); rq.onsuccess=()=>res(true); rq.onerror=()=>rej(rq.error);
+  });
+}
+
+const QUADRANT_WRITE_RETRIES = 3;
+
+export async function loadQuadrantRecord(db, layerIndex, quadrantIndex){
+  if (!db) return { buffer:null, key:null };
+  const primaryKey = `${layerIndex},${quadrantIndex}`;
+  let buffer = await idbGet(db, STORE_LAYER, primaryKey);
+  if (buffer) return { buffer, key:primaryKey };
+
+  const numericKey = [layerIndex, quadrantIndex];
+  try {
+    const legacy = await idbGet(db, STORE_LAYER, numericKey);
+    if (legacy){
+      await idbPut(db, STORE_LAYER, primaryKey, legacy);
+      await idbDelete(db, STORE_LAYER, numericKey);
+      return { buffer:legacy, key:primaryKey };
+    }
+  } catch (err) {
+    // Ignore migration failures; caller will treat as missing
+  }
+
+  return { buffer:null, key:primaryKey };
+}
+
+export async function persistQuadrantRecord(db, layerIndex, quadrantIndex, source, retries = QUADRANT_WRITE_RETRIES){
+  if (!db || !source) return false;
+
+  let payload;
+  if (source instanceof ArrayBuffer){
+    payload = source;
+  } else if (source?.buffer instanceof ArrayBuffer){
+    const view = source;
+    if (view.byteOffset === 0 && view.byteLength === view.buffer.byteLength){
+      payload = view.buffer;
+    } else {
+      payload = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+    }
+  }
+
+  if (!payload) return false;
+
+  const expectedBytes = payload.byteLength || source.byteLength || 0;
+  const key = `${layerIndex},${quadrantIndex}`;
+
+  for (let attempt=0; attempt<retries; attempt++){
+    try {
+      await idbPut(db, STORE_LAYER, key, payload);
+      const verify = await idbGet(db, STORE_LAYER, key);
+      const actualBytes = verify instanceof ArrayBuffer
+        ? verify.byteLength
+        : (verify?.byteLength ?? (verify?.buffer?.byteLength ?? 0));
+      if (actualBytes === expectedBytes) return true;
+    } catch (err) {
+      // Retry below
+    }
+    await new Promise(res=>setTimeout(res,0));
+  }
+
+  if (typeof console !== 'undefined' && console?.warn){
+    console.warn('[SDFGrid] Failed to persist quadrant', layerIndex, quadrantIndex);
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- add storage bucket helpers to dynamically load or persist individual layer quadrants without creating extra IndexedDB entries
- rework dense layer initialization to sequentially ensure quadrants exist, using the zero template for any missing data
- flush quadrant updates through the new helper to maintain ordered per-quadrant writes after initialization

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c97c050194832da78ebd72b519ae38