### PR TITLE
Add contextual bucket orchestrator for vec2 data persistence

### DIFF
--- a/SDFGridCore.js
+++ b/SDFGridCore.js
@@ -46,6 +46,7 @@ import {
 } from './SDFGridState.js';
 import { layerInfo, readCell, centerCell } from './SDFGridConsole.js';
 import { envExpressionFromModule, parseEnvExpression } from './SDFGridEnvExpressions.js';
+import Vec2BucketManager from './vec2BucketManager.js';
 
 export class SDFGrid{
   constructor(uid, scene, params){
@@ -95,6 +96,38 @@ export class SDFGrid{
     this.bucketNameLC = normalizeBucketName(this.uid);
     this._bucket = null;
     this._db     = null;
+
+    this._vec2ManagerPromise = null;
+    this._vec2LastEntries = new Map();
+    if (typeof window !== 'undefined' && (typeof window.indexedDB !== 'undefined' || (typeof navigator !== 'undefined' && navigator.storageBuckets))) {
+      const baseContext = {
+        card: 'sdfgrid',
+        repo: this.uid,
+        file: params?.shapeType || 'grid',
+        group: 'default',
+        forceBucket: this.bucketNameLC
+      };
+      this._vec2ManagerPromise = Vec2BucketManager.create({
+        context: baseContext,
+        resolver: () => this.bucketNameLC,
+        reliability: {
+          enabled: true,
+          onLog: (lvl, ...args) => {
+            if (lvl === 'warn') console.warn('[Vec2Buckets reliability]', ...args);
+          }
+        },
+        onLog: (lvl, ...args) => {
+          if (typeof lvl === 'string' && /warn|error/i.test(lvl)) {
+            console.warn('[Vec2Buckets]', lvl, ...args);
+          }
+        }
+      }).catch(err => {
+        console.warn('Vec2BucketManager init failed:', err);
+        return null;
+      });
+    } else {
+      this._vec2ManagerPromise = Promise.resolve(null);
+    }
 
     // overlay schema
     const initialFields = Array.isArray(params.fieldNames)&&params.fieldNames.length ? params.fieldNames.slice() : this.envVariables.slice();

--- a/SDFGridPersistence.js
+++ b/SDFGridPersistence.js
@@ -10,7 +10,7 @@ export function saveLogic(){
   lsSet(logicKey(this.uid), payload);
 }
 
-export function saveBlobs(){
+export async function saveBlobs(){
   const sparse=[];
   for (let z=0; z<this.effectiveCellsZ; z++){
     for (let y=0; y<this.state.cellsY; y++){
@@ -35,6 +35,58 @@ export function saveBlobs(){
     envVariables:this.envVariables, data:sparse, ts:Date.now(), uid:this.uid
   });
   updateRegistrySaved(this.uid);
+
+  if (this._vec2ManagerPromise){
+    try {
+      const manager = await this._vec2ManagerPromise;
+      if (manager){
+        const fieldNames = Array.isArray(this.schema?.fieldNames) ? this.schema.fieldNames.slice() : [];
+        const makeKey = (x,y,z) => `${x}|${y}|${z}`;
+        const encodeVec2 = (x,y,z) => [ (z * this.state.cellsX) + x, y ];
+        const nextEntries = new Map();
+        const entries = [];
+
+        if (fieldNames.length){
+          for (const cell of sparse){
+            if (!cell || typeof cell.x !== 'number' || typeof cell.y !== 'number' || typeof cell.z !== 'number') continue;
+            const data = (cell.data && typeof cell.data === 'object') ? cell.data : null;
+            if (!data) continue;
+            const values = fieldNames.map(name => Number(data[name] ?? 0));
+            const hasValue = values.some(v => v !== 0);
+            if (!hasValue) continue;
+            const vec2 = encodeVec2(cell.x, cell.y, cell.z);
+            const tagGroup = `layer-${cell.z}`;
+            entries.push({ vec2, values, tagGroup, tagNames: fieldNames });
+            nextEntries.set(makeKey(cell.x, cell.y, cell.z), { vec2, tagGroup });
+          }
+        }
+
+        const BATCH_SIZE = 4000;
+        for (let i = 0; i < entries.length; i += BATCH_SIZE){
+          const chunk = entries.slice(i, i + BATCH_SIZE);
+          if (chunk.length) await manager.bulkPreserve(chunk);
+        }
+
+        const deletions = [];
+        if (this._vec2LastEntries && this._vec2LastEntries.size){
+          for (const [key, stored] of this._vec2LastEntries.entries()){
+            if (!nextEntries.has(key)){
+              const vec = Array.isArray(stored?.vec2) ? stored.vec2 : stored;
+              deletions.push(manager.deleteValue(vec));
+              const tagGroup = stored?.tagGroup;
+              if (tagGroup){
+                deletions.push(manager.deleteVec2Tags(tagGroup, vec));
+              }
+            }
+          }
+        }
+        if (deletions.length) await Promise.allSettled(deletions);
+        this._vec2LastEntries = nextEntries;
+      }
+    } catch (err) {
+      console.warn('Vec2 bucket sync failed:', err?.message || err);
+    }
+  }
 }
 
 export function loadState(uid){ return lsGet(stateKey(uid)); }

--- a/SDFGridState.js
+++ b/SDFGridState.js
@@ -73,6 +73,13 @@ export async function updateGrid(params){
   this.state.shapeType  = params.shapeType  || this.state.shapeType;
   this.state.customSVGPath = params.customSVGPath || this.state.customSVGPath;
 
+  if (this._vec2ManagerPromise){
+    this._vec2ManagerPromise.then(mgr => {
+      mgr?.setBaseContext?.({ file: this.state.shapeType || 'grid' });
+      return mgr;
+    }).catch(()=>{});
+  }
+
   if (Array.isArray(params.fieldNames) && params.fieldNames.length){
     await this.evolveSchema(params.fieldNames);
     this.fieldForViz = this.fieldForViz && this.schema.index.has(this.fieldForViz) ? this.fieldForViz : this.schema.fieldNames[0];
@@ -86,6 +93,7 @@ export async function updateGrid(params){
   this._layerCache.clear();
   this._dirtyLayers.clear();
   if (this._flushHandle){ clearTimeout(this._flushHandle); this._flushHandle=null; }
+  this._vec2LastEntries = new Map();
 
   this.initializeGrid();
 
@@ -197,6 +205,17 @@ export function dispose(){
     this.scene.remove(this.gridGroup);
     this.gridGroup.traverse(o=>{ if(o.geometry)o.geometry.dispose(); if(o.material)o.material.dispose(); });
     this.gridGroup=null; this.instancedMesh=null;
+  }
+  if (this._vec2ManagerPromise){
+    this._vec2ManagerPromise.then(mgr => {
+      try { mgr?.stopReliability?.(); } catch (e) { /* noop */ }
+      return mgr;
+    }).catch(()=>{});
+    this._vec2ManagerPromise = null;
+  }
+  if (this._vec2LastEntries){
+    try { this._vec2LastEntries.clear(); } catch(e) { /* noop */ }
+    this._vec2LastEntries = new Map();
   }
   this._layerCache.clear();
   this._dirtyLayers.clear();

--- a/bucketOrchestrator.js
+++ b/bucketOrchestrator.js
@@ -1,0 +1,316 @@
+// bucketOrchestrator.js
+// A mostly-standalone controller module that is "directed" by an external
+// edge-case library to contextually manage Storage Buckets and delegate vec2
+// reads/writes to your existing Vec2StorageManager.
+//
+// How it works
+// - You register edge-case rules (sync or async). Rules receive {context, op, payload}
+//   and may: (a) mutate context, (b) veto or reroute the op, (c) change bucket name,
+//   (d) request retries/migrations, (e) apply custom tag policies.
+// - You provide a bucketNameResolver(context) → string. It’s sanitized/lowercased.
+// - The orchestrator ensures bucket/DB availability, then delegates to Vec2StorageManager.
+// - Includes: retry policy, validation, migration between buckets, and bulk preservation.
+//
+// Dependencies: ./vec2StorageManager.js (the module you already have)
+//
+// Example usage (outside this file):
+//   import Orchestrator from './bucketOrchestrator.js';
+//   import rules from './myEdgeCaseLibrary.js';
+//   const orch = new Orchestrator({ bucketNameResolver: ctx => `${ctx.card}${ctx.repo}${ctx.file}statecapture` });
+//   orch.registerRules(rules);
+//   await orch.init({ card:'c001', repo:'0xb1', file:'0xf1' });
+//   await orch.setValue([10,20], [1,2,3], { group:'chem' });
+//   const got = await orch.getValueWithNames([10,20], { group:'chem' });
+//
+// Notes
+// - Bucket names are force-lowercased and sanitized to [a-z0-9-]. (Hyphens kept, others dropped.)
+// - If Storage Buckets API is unavailable, falls back to window.indexedDB inside orchestrated flow.
+// - All public methods accept an optional {contextOverride} to re-resolve bucket per call.
+
+import Vec2StorageManager from './vec2StorageManager.js';
+
+export default class BucketOrchestrator {
+  /**
+   * @param {object} opts
+   *  - bucketNameResolver(context): (required) function -> string bucket name (any case); will be sanitized/lowercased.
+   *  - dbName: string (default 'Vec2DB')
+   *  - dbVersion: number (default 1)
+   *  - dataStore: string (default 'vec2Data')
+   *  - tagStore: string (default 'vec2Tags')
+   *  - retry: { attempts:number, delayMs:number } (default {attempts:2, delayMs:80})
+   *  - forbidEmptyBucket: boolean (default true)
+   *  - onLog: (level, ...args) => void (optional)
+   */
+  constructor(opts = {}) {
+    if (typeof opts.bucketNameResolver !== 'function') {
+      throw new Error('bucketNameResolver(context) is required');
+    }
+    this.resolveBucket = opts.bucketNameResolver;
+    this.dbName = opts.dbName ?? 'Vec2DB';
+    this.dbVersion = opts.dbVersion ?? 1;
+    this.dataStore = opts.dataStore ?? 'vec2Data';
+    this.tagStore = opts.tagStore ?? 'vec2Tags';
+    this.retry = Object.assign({ attempts: 2, delayMs: 80 }, opts.retry || {});
+    this.forbidEmptyBucket = opts.forbidEmptyBucket ?? true;
+    this.log = typeof opts.onLog === 'function' ? opts.onLog : () => {};
+
+    /** @type {Map<string, Vec2StorageManager>} */
+    this._storeCache = new Map();
+    /** @type {Array<Function>} rule fns: (ctx, op) => RuleResult|void */
+    this._rules = [];
+    this._baseContext = null;
+  }
+
+  // ---------------------- Edge-case rules API ----------------------
+
+  /**
+   * Register one or more rule functions.
+   * A rule receives: ({ context, op, payload, orchestrator }) and can:
+   *  - mutate context (e.g., context.card = 'c002')
+   *  - return { rerouteBucketName?, abort?, replacePayload?, delayMs?, retry? }
+   */
+  registerRule(ruleFnOrArray) {
+    const arr = Array.isArray(ruleFnOrArray) ? ruleFnOrArray : [ruleFnOrArray];
+    for (const fn of arr) {
+      if (typeof fn !== 'function') throw new Error('rule must be a function');
+      this._rules.push(fn);
+    }
+  }
+
+  async _applyRules(op, payload, context) {
+    let ctx = { ...(this._baseContext || {}), ...(context || {}) };
+    let pl = payload;
+    let reroute = null;
+    for (const fn of this._rules) {
+      const res = await Promise.resolve(fn({ context: ctx, op, payload: pl, orchestrator: this }));
+      if (!res) continue;
+      if (res.abort) throw new Error(`Operation "${op}" aborted by edge-case rule`);
+      if (res.replacePayload !== undefined) pl = res.replacePayload;
+      if (typeof res.rerouteBucketName === 'string') reroute = res.rerouteBucketName;
+      if (typeof res.delayMs === 'number' && res.delayMs > 0) {
+        await new Promise(r => setTimeout(r, res.delayMs));
+      }
+      if (res.retry && typeof res.retry === 'object') {
+        // Allow a rule to override retry behavior for the next execution frame.
+        this._lastRuleRetry = res.retry;
+      }
+    }
+    return { context: ctx, payload: pl, rerouteBucketName: reroute };
+  }
+
+  // ---------------------- Init / store resolution ----------------------
+
+  /**
+   * Initialize orchestrator with a base context (e.g., {card, repo, file, group})
+   */
+  async init(baseContext = {}) {
+    this._baseContext = { ...baseContext };
+    // Pre-resolve bucket lazily; do nothing here to allow rules to intervene on first op.
+    this.log('info', 'Orchestrator initialized', this._baseContext);
+  }
+
+  _sanitizeBucketName(name) {
+    if (typeof name !== 'string') name = String(name ?? '');
+    // keep [a-z0-9-], drop others; lowercase
+    return name.toLowerCase().replace(/[^a-z0-9-]/g, '');
+  }
+
+  _bucketKeyFromContext(ctx, explicitReroute) {
+    const raw = explicitReroute ?? this.resolveBucket(ctx);
+    const sanitized = this._sanitizeBucketName(raw);
+    if (!sanitized && this.forbidEmptyBucket) {
+      throw new Error('Resolved empty bucket name (forbidden). Provide a valid context or resolver.');
+    }
+    return sanitized || 'default-bucket';
+  }
+
+  async _getStoreForContext(ctx, rerouteName) {
+    const bucketName = this._bucketKeyFromContext(ctx, rerouteName);
+    if (this._storeCache.has(bucketName)) return this._storeCache.get(bucketName);
+
+    const store = new Vec2StorageManager(bucketName, {
+      dbName: this.dbName,
+      dbVersion: this.dbVersion,
+      dataStore: this.dataStore,
+      tagStore: this.tagStore
+    });
+    await store.init();
+    this._storeCache.set(bucketName, store);
+    return store;
+  }
+
+  // ---------------------- Retry wrapper ----------------------
+
+  async _withRetry(fn, opLabel) {
+    const policy = this._lastRuleRetry || this.retry;
+    this._lastRuleRetry = null;
+    let attempt = 0;
+    let delay = policy.delayMs;
+    let lastErr;
+    while (attempt < policy.attempts) {
+      try {
+        return await fn();
+      } catch (e) {
+        lastErr = e;
+        this.log('warn', `${opLabel} failed (attempt ${attempt + 1}/${policy.attempts})`, e?.message || e);
+        if (attempt + 1 >= policy.attempts) break;
+        await new Promise(r => setTimeout(r, delay));
+        delay *= 1.4; // backoff
+      }
+      attempt++;
+    }
+    throw lastErr;
+  }
+
+  // ---------------------- Public data operations ----------------------
+
+  async setValue(vec2, values, { group, contextOverride } = {}) {
+    const op = 'setValue';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { vec2, values, group }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      // Optional: rule may request pre-tag policy (e.g., ensure name slots)
+      if (Array.isArray(context.ensureNameSlots) && typeof group === 'string') {
+        const cur = (await store.getVec2Tags(group, vec2)) ?? [];
+        const len = Math.max(cur.length, context.ensureNameSlots.length);
+        const names = new Array(len).fill('');
+        for (let i = 0; i < len; i++) names[i] = context.ensureNameSlots[i] ?? cur[i] ?? '';
+        await store.setVec2Tags(group, vec2, names);
+      }
+      return store.setValue(payload.vec2, payload.values);
+    }, op);
+  }
+
+  async getValue(vec2, { contextOverride } = {}) {
+    const op = 'getValue';
+    const { context, rerouteBucketName } = await this._applyRules(op, { vec2 }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.getValue(vec2);
+    }, op);
+  }
+
+  async getValueWithNames(vec2, { group, contextOverride } = {}) {
+    const op = 'getValueWithNames';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { vec2, group }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.getValueWithNames(payload.vec2, payload.group);
+    }, op);
+  }
+
+  async updateValue(vec2, index, value, { contextOverride } = {}) {
+    const op = 'updateValue';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { vec2, index, value }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.updateValue(payload.vec2, payload.index, payload.value);
+    }, op);
+  }
+
+  async deleteValue(vec2, { contextOverride } = {}) {
+    const op = 'deleteValue';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { vec2 }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.deleteValue(payload.vec2);
+    }, op);
+  }
+
+  // ---------------------- Tag operations ----------------------
+
+  async setVec2Tags(group, vec2, names, { contextOverride } = {}) {
+    const op = 'setVec2Tags';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { group, vec2, names }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.setVec2Tags(payload.group, payload.vec2, payload.names);
+    }, op);
+  }
+
+  async setVec2TagName(group, vec2, index, name, { contextOverride } = {}) {
+    const op = 'setVec2TagName';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { group, vec2, index, name }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.setVec2TagName(payload.group, payload.vec2, payload.index, payload.name);
+    }, op);
+  }
+
+  async getVec2Tags(group, vec2, { contextOverride } = {}) {
+    const op = 'getVec2Tags';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { group, vec2 }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.getVec2Tags(payload.group, payload.vec2);
+    }, op);
+  }
+
+  async deleteVec2Tags(group, vec2, { contextOverride } = {}) {
+    const op = 'deleteVec2Tags';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { group, vec2 }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      return store.deleteVec2Tags(payload.group, payload.vec2);
+    }, op);
+  }
+
+  // ---------------------- Bulk preservation ----------------------
+
+  /**
+   * bulkPreserve with context-aware routing and optional rule-driven transforms.
+   * entries: [{ vec2:[x,y], values:number[], tagGroup?:string, tagNames?:string[] }, ...]
+   */
+  async bulkPreserve(entries, { contextOverride } = {}) {
+    const op = 'bulkPreserve';
+    const { context, payload, rerouteBucketName } = await this._applyRules(op, { entries }, contextOverride);
+    return this._withRetry(async () => {
+      const store = await this._getStoreForContext(context, rerouteBucketName);
+      const toWrite = Array.isArray(payload.entries) ? payload.entries : [];
+      return store.bulkPreserve(toWrite);
+    }, op);
+  }
+
+  // ---------------------- Migrations & Utilities ----------------------
+
+  /**
+   * Migrate a set of vec2 keys (and optional tags) from oldContext → newContext in bulk.
+   * You provide a list of {vec2, includeTags?:boolean, groups?:string[]}
+   */
+  async migrate({ fromContext, toContext, items }) {
+    const fromStore = await this._getStoreForContext(fromContext);
+    const toStore = await this._getStoreForContext(toContext);
+
+    // Read all entries first
+    const payload = [];
+    for (const it of items || []) {
+      const arr = await fromStore.getValue(it.vec2);
+      if (arr) {
+        payload.push({ vec2: it.vec2, values: Array.from(arr) });
+      }
+    }
+    const res = await toStore.bulkPreserve(payload);
+
+    // Copy tags if requested
+    let tagged = 0;
+    for (const it of items || []) {
+      if (!it.includeTags) continue;
+      const groups = Array.isArray(it.groups) && it.groups.length ? it.groups : [ 'default' ];
+      for (const g of groups) {
+        const names = await fromStore.getVec2Tags(g, it.vec2);
+        if (names && names.length) {
+          await toStore.setVec2Tags(g, it.vec2, names);
+          tagged++;
+        }
+      }
+    }
+    return { written: res.written, tagged: res.tagged + tagged };
+  }
+
+  /**
+   * Forget all cached store instances (does not delete data).
+   */
+  resetCache() {
+    this._storeCache.clear();
+  }
+}

--- a/myEdgeCaseLibrary.js
+++ b/myEdgeCaseLibrary.js
@@ -1,0 +1,307 @@
+// myEdgeCaseLibrary.js
+// A “directing” rule set for BucketOrchestrator. Each rule can:
+//  • read/mutate context
+//  • return { rerouteBucketName?, abort?, replacePayload?, delayMs?, retry? }
+//  • validate / normalize vec2 and tag inputs
+//  • shard or time-slice bucket routing
+//  • throttle duplicates
+//
+// Usage:
+//   import buildRules, { defaultEdgeOptions } from './myEdgeCaseLibrary.js';
+//   orchestrator.registerRule(buildRules({ /* overrides */ }));
+//
+// Notes:
+//  - Rules are pure(ish) functions operating on {context, op, payload, orchestrator}.
+//  - Keep heavy I/O outside rules; prefer hints that the orchestrator acts upon.
+//  - BucketOrchestrator will still sanitize/lowercase the final bucket name.
+
+export const defaultEdgeOptions = {
+  // If provided and context is missing card/repo/file, these defaults are used.
+  contextDefaults: { card: 'c000', repo: '0x00', file: '0x00', group: 'default' },
+
+  // For sharding by vec2 coordinate:
+  shard: {
+    enabled: true,
+    sizeX: 256,  // cells per shard on x
+    sizeY: 256,  // cells per shard on y
+    // Final bucket name becomes: resolver(context) + `-s${sx}x${sy}`
+    // Example: "c0010xb10xf1statecapture-s0x1"
+  },
+
+  // Time-slicing: append YYYYMMDD to bucket for ops labeled in timeSliceOps.
+  timeSlicing: {
+    enabled: false,
+    timeSliceOps: new Set(['bulkPreserve']), // ops it applies to
+    // time zone insensitive: uses local date
+  },
+
+  // Lightweight duplicate-write throttle window (ms)
+  throttleMs: 60,
+
+  // Max array length for a single value write (prevents accidental megabyte writes)
+  maxValuesPerWrite: 8192,
+
+  // Max bulk entries per transaction (guardrails only; actual IDB can handle more)
+  maxBulkEntries: 5000,
+
+  // Retry overrides when rules detect transient conditions
+  transientRetry: { attempts: 3, delayMs: 120 },
+
+  // When quotaLow is set on context, spill writes to a suffix
+  spillSuffix: '-spill',
+
+  // If present in context, maps bucketAlias -> actual base bucket (before sharding/time-slicing/spill)
+  aliasMap: {
+    // 'work': (ctx) => `${ctx.card}${ctx.repo}${ctx.file}statecapture`
+  }
+};
+
+// ----------------------------- helpers -----------------------------
+
+function isFiniteNum(n) { return Number.isFinite(n); }
+
+function normalizeVec2(maybeVec2) {
+  if (!Array.isArray(maybeVec2) || maybeVec2.length !== 2) return null;
+  const x = Number(maybeVec2[0]);
+  const y = Number(maybeVec2[1]);
+  return (isFiniteNum(x) && isFiniteNum(y)) ? [x, y] : null;
+}
+
+function normalizeGroup(group) {
+  if (group == null) return 'default';
+  const s = String(group).trim();
+  return s.length ? s : 'default';
+}
+
+function shardSuffix(vec2, sizeX, sizeY) {
+  const [x, y] = vec2;
+  const sx = Math.floor(x / sizeX);
+  const sy = Math.floor(y / sizeY);
+  return `-s${sx}x${sy}`;
+}
+
+function yyyymmdd(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}${m}${day}`;
+}
+
+// In-memory throttle cache (module-scope)
+const _recentWrites = new Map(); // key -> ts
+
+function makeRecentKey(op, payload) {
+  try {
+    if (op === 'bulkPreserve') {
+      // key based on first & length for a cheap signature
+      const first = payload?.entries?.[0] ?? {};
+      return `${op}:${JSON.stringify(first)}:${payload?.entries?.length || 0}`;
+    }
+    return `${op}:${JSON.stringify(payload)}`;
+  } catch {
+    return `${op}:opaque`;
+  }
+}
+
+// Clamp numeric arrays; coerce non-numbers to 0; trim length cap
+function sanitizeNumericArray(arr, maxLen) {
+  if (!Array.isArray(arr) && !ArrayBuffer.isView(arr)) return [];
+  const out = [];
+  const lim = Math.min(maxLen, Number(arr.length || 0));
+  for (let i = 0; i < lim; i++) {
+    const v = Number(arr[i]);
+    out.push(isFiniteNum(v) ? v : 0);
+  }
+  return out;
+}
+
+function sanitizeNamesArray(names) {
+  if (!Array.isArray(names)) return [];
+  return names.map(n => (n == null ? '' : String(n)));
+}
+
+// ---------------------------- rules builder ----------------------------
+
+export default function buildRules(options = {}) {
+  const cfg = {
+    ...defaultEdgeOptions,
+    ...options,
+    shard: { ...defaultEdgeOptions.shard, ...(options.shard || {}) },
+    timeSlicing: { ...defaultEdgeOptions.timeSlicing, ...(options.timeSlicing || {}) }
+  };
+
+  // Rule 1: Ensure baseline context; support alias mapping.
+  async function ensureContext({ context, op }) {
+    // Fill defaults
+    for (const k of Object.keys(cfg.contextDefaults)) {
+      if (context[k] == null || context[k] === '') {
+        context[k] = cfg.contextDefaults[k];
+      }
+    }
+    // Resolve alias -> base bucket prefix (before orchestrator resolver runs)
+    if (context.bucketAlias && cfg.aliasMap && cfg.aliasMap[context.bucketAlias]) {
+      // Provide a hint: let orchestrator’s resolver read context.baseBucket if it wants.
+      const mapper = cfg.aliasMap[context.bucketAlias];
+      context.baseBucket = typeof mapper === 'function' ? mapper(context) : String(mapper);
+    }
+    // Normalize group where relevant
+    if (op === 'setVec2Tags' || op === 'setVec2TagName' || op === 'getVec2Tags' || op === 'getValueWithNames') {
+      context.group = normalizeGroup(context.group);
+    }
+  }
+
+  // Rule 2: Normalize/validate payload shapes; cap sizes.
+  async function normalizePayload({ op, payload }) {
+    if (op === 'setValue' || op === 'updateValue' || op === 'getValue' || op === 'getValueWithNames' || op === 'deleteValue') {
+      const vec2 = normalizeVec2(payload.vec2);
+      if (!vec2) return { abort: true };
+      if (op === 'setValue') {
+        const values = sanitizeNumericArray(payload.values, cfg.maxValuesPerWrite);
+        return { replacePayload: { vec2, values, group: normalizeGroup(payload.group) } };
+      } else if (op === 'updateValue') {
+        const idx = Math.max(0, Number(payload.index) | 0);
+        const value = Number(payload.value);
+        return { replacePayload: { vec2, index: idx, value: isFiniteNum(value) ? value : 0 } };
+      } else if (op === 'getValueWithNames') {
+        return { replacePayload: { vec2, group: normalizeGroup(payload.group) } };
+      }
+      return { replacePayload: { ...payload, vec2 } };
+    }
+
+    if (op === 'setVec2Tags' || op === 'setVec2TagName' || op === 'getVec2Tags' || op === 'deleteVec2Tags') {
+      const vec2 = normalizeVec2(payload.vec2);
+      if (!vec2) return { abort: true };
+      if (op === 'setVec2Tags') {
+        return { replacePayload: { group: normalizeGroup(payload.group), vec2, names: sanitizeNamesArray(payload.names) } };
+      } else if (op === 'setVec2TagName') {
+        const idx = Math.max(0, Number(payload.index) | 0);
+        const name = String(payload.name ?? '');
+        return { replacePayload: { group: normalizeGroup(payload.group), vec2, index: idx, name } };
+      } else {
+        return { replacePayload: { group: normalizeGroup(payload.group), vec2 } };
+      }
+    }
+
+    if (op === 'bulkPreserve') {
+      const raw = Array.isArray(payload.entries) ? payload.entries.slice(0, cfg.maxBulkEntries) : [];
+      const entries = raw.map(e => {
+        const v2 = normalizeVec2(e.vec2);
+        if (!v2) return null;
+        const values = sanitizeNumericArray(e.values, cfg.maxValuesPerWrite);
+        const tagGroup = e.tagGroup != null ? normalizeGroup(e.tagGroup) : undefined;
+        const tagNames = Array.isArray(e.tagNames) ? sanitizeNamesArray(e.tagNames) : undefined;
+        return { vec2: v2, values, tagGroup, tagNames };
+      }).filter(Boolean);
+      // Deduplicate by vec2 + (optional) tagGroup quickly
+      const seen = new Set();
+      const deduped = [];
+      for (const e of entries) {
+        const key = `${e.vec2[0]}|${e.vec2[1]}|${e.tagGroup || ''}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        deduped.push(e);
+      }
+      return { replacePayload: { entries: deduped } };
+    }
+  }
+
+  // Rule 3: Throttle duplicate writes briefly to avoid hammering IDB.
+  async function throttleDuplicates({ op, payload }) {
+    if (!cfg.throttleMs) return;
+    if (op === 'getValue' || op === 'getVec2Tags' || op === 'getValueWithNames') return; // reads are fine
+
+    const key = makeRecentKey(op, payload);
+    const now = performance.now?.() || Date.now();
+    const last = _recentWrites.get(key) || 0;
+    if (now - last < cfg.throttleMs) {
+      return { abort: true }; // silently drop; caller can re-issue later
+    }
+    _recentWrites.set(key, now);
+  }
+
+  // Rule 4: Optional pre-sizing of names when writing values (so orchestrator can ensure slots)
+  async function ensureNameSlotsHint({ op, payload, context }) {
+    if (op === 'setValue' && typeof context.ensureNameSlots === 'undefined') {
+      // If a group is provided and you want names array to match length of values:
+      if (payload.group && Array.isArray(payload.values)) {
+        context.ensureNameSlots = new Array(payload.values.length).fill('');
+      }
+    }
+  }
+
+  // Rule 5: Routing — shard by vec2; time slicing; spill on quotaLow; alias mapping
+  async function routing({ op, payload, context }) {
+    // Base route hint (edge lib doesn't compute full name; resolver uses context)
+    context.routeSuffix = '';
+
+    // Shard by vec2 for writes and lookups involving a single vec2
+    if (cfg.shard.enabled) {
+      // ops that carry a single vec2:
+      const singleVec2Ops = new Set([
+        'setValue', 'getValue', 'getValueWithNames', 'updateValue', 'deleteValue',
+        'setVec2Tags', 'setVec2TagName', 'getVec2Tags', 'deleteVec2Tags'
+      ]);
+      if (singleVec2Ops.has(op)) {
+        const v2 = payload.vec2;
+        if (v2) context.routeSuffix += shardSuffix(v2, cfg.shard.sizeX, cfg.shard.sizeY);
+      } else if (op === 'bulkPreserve' && payload.entries?.length) {
+        // Coarse shard: pick first entry to choose a shard
+        const v2 = payload.entries[0].vec2;
+        if (v2) context.routeSuffix += shardSuffix(v2, cfg.shard.sizeX, cfg.shard.sizeY);
+      }
+    }
+
+    // Time-slicing for certain ops
+    if (cfg.timeSlicing.enabled && cfg.timeSlicing.timeSliceOps.has(op)) {
+      context.routeSuffix += `-${yyyymmdd(new Date())}`;
+    }
+
+    // Spill routing if caller hints low quota
+    if (context.quotaLow && cfg.spillSuffix) {
+      context.routeSuffix += cfg.spillSuffix;
+      return { retry: cfg.transientRetry }; // nudge orchestrator to be patient
+    }
+
+    // If a rule wants to hard reroute, it can return rerouteBucketName:
+    if (context.forceBucket) {
+      return { rerouteBucketName: String(context.forceBucket) + (context.routeSuffix || '') };
+    }
+  }
+
+  // Rule 6: Gentle backoff for bulk
+  async function bulkBackoff({ op }) {
+    if (op === 'bulkPreserve') {
+      return { retry: cfg.transientRetry };
+    }
+  }
+
+  // Compose all rules (order matters)
+  const rules = [
+    ensureContext,
+    normalizePayload,
+    throttleDuplicates,
+    ensureNameSlotsHint,
+    routing,
+    bulkBackoff
+  ];
+
+  // Return a single callable rule for orchestrator.registerRule(...)
+  return async function myEdgeCaseRulePack(args) {
+    let out = undefined;
+    for (const r of rules) {
+      // If a prior rule returned abort, stop early
+      if (out?.abort) return out;
+      const res = await r(args);
+      // merge semantics: last writer wins for fields
+      if (res) {
+        out = { ...(out || {}), ...res };
+        // replacePayload should carry forward to next rules
+        if (res.replacePayload !== undefined) {
+          args = { ...args, payload: res.replacePayload };
+        }
+        // rerouteBucketName / retry / delayMs flow straight through
+      }
+    }
+    return out;
+  };
+}

--- a/reliabilityEdgeRule.js
+++ b/reliabilityEdgeRule.js
@@ -1,0 +1,328 @@
+// reliabilityEdgeRule.js
+// A queue-backed reliability layer implemented as an edge-case rule pack.
+// Ensures "what was meant to be stored" is indeed stored—even under load.
+//
+// Usage:
+//   import installReliability from './reliabilityEdgeRule.js';
+//   const { rule, worker } = installReliability(orch, { /* options */ });
+//   orch.registerRule(rule);
+//   worker.start();
+//   // ... later: worker.stop();
+//
+// Works with BucketOrchestrator + vec2StorageManager.js.
+// The rule enqueues any write-like op. The worker verifies by read-back,
+// and retries missing/partial entries until success or exhaustion.
+//
+// Supported ops: setValue, updateValue, deleteValue, setVec2Tags, setVec2TagName, bulkPreserve, migrate (best-effort)
+
+export default function installReliability(orchestrator, options = {}) {
+  const cfg = {
+    // Core loop
+    tickMs: 180,                 // base tick interval
+    maxPerTick: 24,              // limit how many queue items to touch per tick
+    // Attempts & backoff
+    maxAttempts: 8,              // per item
+    baseRetryMs: 160,            // initial retry delay per item
+    backoff: 1.7,                // multiplicative backoff
+    jitterPct: 0.25,             // ±25% jitter
+    // Equality checks
+    floatEpsilon: 1e-9,          // equality tolerance for float arrays
+    // Bulk handling
+    verifyAllBulk: true,         // verify each entry in bulkPreserve
+    // Logging
+    onLog: (lvl, ...args) => { /* silent by default */ },
+    ...options
+  };
+
+  // ----------------------------- Queue model -----------------------------
+  // Unified queue item variants. All have a "kind" and "context" (used by resolver).
+  // We store a minimal "write attempt" footprint + "verify" footprint.
+  //
+  // KINDS:
+  //  - 'setValue'      : { vec2:[x,y], values:number[], group?:string }
+  //  - 'updateValue'   : { vec2:[x,y], index:number, value:number }
+  //  - 'deleteValue'   : { vec2:[x,y] }
+  //  - 'setVec2Tags'   : { group:string, vec2:[x,y], names:string[] }
+  //  - 'setVec2TagName': { group:string, vec2:[x,y], index:number, name:string }
+  //  - 'bulkPreserve'  : { entries:[{vec2,values,tagGroup?,tagNames?}, ...] } (expanded internally)
+  //
+  // Queue items get an "id" for dedup + status tracking.
+
+  const _q = new Map(); // id -> entry
+
+  function keyFor(op, payload, context) {
+    // Compose a deterministic identity for deduplication.
+    // Note: for bulk we will expand to per-entry items; identity is per vec2 (+ group when tags exist).
+    const ctxKey = `${context.card}|${context.repo}|${context.file}|${context.group ?? ''}|${context.routeSuffix ?? ''}|${context.forceBucket ?? ''}|${context.bucketAlias ?? ''}`;
+    switch (op) {
+      case 'setValue':
+        return `SV:${ctxKey}:${payload.vec2[0]}|${payload.vec2[1]}:${payload.values.length}`;
+      case 'updateValue':
+        return `UV:${ctxKey}:${payload.vec2[0]}|${payload.vec2[1]}:${payload.index}`;
+      case 'deleteValue':
+        return `DV:${ctxKey}:${payload.vec2[0]}|${payload.vec2[1]}`;
+      case 'setVec2Tags':
+        return `ST:${ctxKey}:${payload.group}|${payload.vec2[0]}|${payload.vec2[1]}:${payload.names.length}`;
+      case 'setVec2TagName':
+        return `SN:${ctxKey}:${payload.group}|${payload.vec2[0]}|${payload.vec2[1]}:${payload.index}`;
+      case 'bulkPreserve':
+        // we expand later; this key is not used for storage
+        return `BP:${ctxKey}:${payload.entries?.length || 0}`;
+      case 'migrate':
+        return `MG:${ctxKey}:${(payload.items?.length || 0)}`;
+      default:
+        return `OP:${op}:${ctxKey}`;
+    }
+  }
+
+  function enqueue(item) {
+    const id = item.id;
+    if (_q.has(id)) {
+      // refresh desired payload (e.g., subsequent write supersedes older)
+      const ex = _q.get(id);
+      ex.payload = item.payload;
+      ex.touch = Date.now();
+      return ex;
+    }
+    _q.set(id, {
+      ...item,
+      attempts: 0,
+      nextAt: Date.now(),
+      touch: Date.now()
+    });
+    return item;
+  }
+
+  function remove(id) {
+    _q.delete(id);
+  }
+
+  function randJitter(ms) {
+    const mag = ms * cfg.jitterPct;
+    return ms + (Math.random() * 2 - 1) * mag;
+  }
+
+  // ----------------------------- Comparators -----------------------------
+
+  function floatsEqual(a, b, eps = cfg.floatEpsilon) {
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (Math.abs(Number(a[i]) - Number(b[i])) > eps) return false;
+    }
+    return true;
+  }
+
+  // ----------------------------- Verify & Write helpers ------------------
+
+  async function verifySetValue(ctx, p) {
+    const got = await orchestrator.getValue(p.vec2, { contextOverride: ctx });
+    if (!got) return false;
+    const arr = Array.from(got);
+    return floatsEqual(arr, p.values);
+  }
+
+  async function writeSetValue(ctx, p) {
+    await orchestrator.setValue(p.vec2, p.values, { group: p.group, contextOverride: ctx });
+  }
+
+  async function verifyUpdateValue(ctx, p) {
+    const got = await orchestrator.getValue(p.vec2, { contextOverride: ctx });
+    if (!got) return false;
+    const arr = Array.from(got);
+    return Number(arr[p.index]) === Number(p.value);
+  }
+
+  async function writeUpdateValue(ctx, p) {
+    await orchestrator.updateValue(p.vec2, p.index, p.value, { contextOverride: ctx });
+  }
+
+  async function verifyDeleteValue(ctx, p) {
+    const got = await orchestrator.getValue(p.vec2, { contextOverride: ctx });
+    return got === null; // deleted if not found
+  }
+
+  async function writeDeleteValue(ctx, p) {
+    await orchestrator.deleteValue(p.vec2, { contextOverride: ctx });
+  }
+
+  async function verifySetVec2Tags(ctx, p) {
+    const names = await orchestrator.getVec2Tags(p.group, p.vec2, { contextOverride: ctx });
+    if (!names) return false;
+    // allow extra trailing empty strings on either side
+    const a = p.names.slice();
+    const b = names.slice();
+    // trim trailing empties
+    while (a.length && a[a.length - 1] === '') a.pop();
+    while (b.length && b[b.length - 1] === '') b.pop();
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (String(a[i]) !== String(b[i])) return false;
+    return true;
+  }
+
+  async function writeSetVec2Tags(ctx, p) {
+    await orchestrator.setVec2Tags(p.group, p.vec2, p.names, { contextOverride: ctx });
+  }
+
+  async function verifySetVec2TagName(ctx, p) {
+    const names = await orchestrator.getVec2Tags(p.group, p.vec2, { contextOverride: ctx });
+    if (!names) return false;
+    return String(names[p.index] ?? '') === String(p.name ?? '');
+  }
+
+  async function writeSetVec2TagName(ctx, p) {
+    await orchestrator.setVec2TagName(p.group, p.vec2, p.index, p.name, { contextOverride: ctx });
+  }
+
+  // For bulk we decompose into individual "setValue" + optional "setVec2Tags" items.
+  function expandBulk(context, payload) {
+    const items = [];
+    for (const e of payload.entries || []) {
+      items.push({
+        kind: 'setValue',
+        context,
+        payload: { vec2: e.vec2, values: Array.from(e.values ?? []), group: e.tagGroup }
+      });
+      if (cfg.verifyAllBulk && e.tagGroup && Array.isArray(e.tagNames)) {
+        items.push({
+          kind: 'setVec2Tags',
+          context,
+          payload: { group: e.tagGroup, vec2: e.vec2, names: e.tagNames.slice() }
+        });
+      }
+    }
+    return items;
+  }
+
+  async function verifyAndHeal(entry) {
+    const { kind, context, payload } = entry;
+    try {
+      let ok = false;
+      if (kind === 'setValue')     ok = await verifySetValue(context, payload);
+      else if (kind === 'updateValue') ok = await verifyUpdateValue(context, payload);
+      else if (kind === 'deleteValue') ok = await verifyDeleteValue(context, payload);
+      else if (kind === 'setVec2Tags') ok = await verifySetVec2Tags(context, payload);
+      else if (kind === 'setVec2TagName') ok = await verifySetVec2TagName(context, payload);
+
+      if (ok) return true; // verified
+
+      // Not OK: try to (re)write
+      if (kind === 'setValue')           await writeSetValue(context, payload);
+      else if (kind === 'updateValue')   await writeUpdateValue(context, payload);
+      else if (kind === 'deleteValue')   await writeDeleteValue(context, payload);
+      else if (kind === 'setVec2Tags')   await writeSetVec2Tags(context, payload);
+      else if (kind === 'setVec2TagName')await writeSetVec2TagName(context, payload);
+
+      // Verify again (fast path)
+      if (kind === 'setValue')           return await verifySetValue(context, payload);
+      else if (kind === 'updateValue')   return await verifyUpdateValue(context, payload);
+      else if (kind === 'deleteValue')   return await verifyDeleteValue(context, payload);
+      else if (kind === 'setVec2Tags')   return await verifySetVec2Tags(context, payload);
+      else if (kind === 'setVec2TagName')return await verifySetVec2TagName(context, payload);
+
+      return false;
+    } catch (e) {
+      cfg.onLog('warn', 'verifyAndHeal error', kind, e?.message || e);
+      return false;
+    }
+  }
+
+  // ----------------------------- Worker loop -----------------------------
+
+  let _timer = null;
+  function scheduleNext() {
+    if (_timer) return;
+    _timer = setTimeout(tick, cfg.tickMs);
+  }
+
+  async function tick() {
+    _timer = null;
+    const now = Date.now();
+    const ready = [];
+    for (const [id, it] of _q) {
+      if (it.nextAt <= now) ready.push(it);
+      if (ready.length >= cfg.maxPerTick) break;
+    }
+    for (const it of ready) {
+      if (!_q.has(it.id)) continue;
+      const ok = await verifyAndHeal(it);
+      if (ok) {
+        remove(it.id);
+        cfg.onLog('info', 'verified', it.kind, it.id);
+        continue;
+      }
+      // backoff
+      it.attempts += 1;
+      if (it.attempts >= cfg.maxAttempts) {
+        cfg.onLog('warn', 'exhausted attempts', it.kind, it.id);
+        remove(it.id);
+        continue;
+      }
+      const delay = randJitter(cfg.baseRetryMs * Math.pow(cfg.backoff, it.attempts));
+      it.nextAt = Date.now() + delay;
+      it.touch = Date.now();
+    }
+    scheduleNext();
+  }
+
+  const worker = {
+    start() {
+      scheduleNext();
+      cfg.onLog('info', 'reliability worker started');
+    },
+    stop() {
+      if (_timer) clearTimeout(_timer);
+      _timer = null;
+      cfg.onLog('info', 'reliability worker stopped');
+    },
+    size() { return _q.size; },
+    snapshot() { return Array.from(_q.values()).map(s => ({ id: s.id, kind: s.kind, attempts: s.attempts, nextAt: s.nextAt })); }
+  };
+
+  // ----------------------------- Rule hook ------------------------------
+
+  // This rule observes outbound ops and enqueues verification tasks.
+  async function reliabilityRule({ context, op, payload }) {
+    // Expand and enqueue according to op; do not abort the op.
+    // The actual write proceeds; we verify & heal afterwards.
+    try {
+      if (op === 'setValue') {
+        const id = keyFor(op, payload, context);
+        enqueue({ id, kind: 'setValue', context: { ...context }, payload: { vec2: payload.vec2, values: Array.from(payload.values ?? []), group: payload.group } });
+      } else if (op === 'updateValue') {
+        const id = keyFor(op, payload, context);
+        enqueue({ id, kind: 'updateValue', context: { ...context }, payload: { vec2: payload.vec2, index: payload.index, value: payload.value } });
+      } else if (op === 'deleteValue') {
+        const id = keyFor(op, payload, context);
+        enqueue({ id, kind: 'deleteValue', context: { ...context }, payload: { vec2: payload.vec2 } });
+      } else if (op === 'setVec2Tags') {
+        const id = keyFor(op, payload, context);
+        enqueue({ id, kind: 'setVec2Tags', context: { ...context }, payload: { group: payload.group, vec2: payload.vec2, names: Array.from(payload.names ?? []) } });
+      } else if (op === 'setVec2TagName') {
+        const id = keyFor(op, payload, context);
+        enqueue({ id, kind: 'setVec2TagName', context: { ...context }, payload: { group: payload.group, vec2: payload.vec2, index: payload.index, name: String(payload.name ?? '') } });
+      } else if (op === 'bulkPreserve') {
+        // Decompose into per-entry tasks.
+        const items = expandBulk({ ...context }, payload);
+        for (const it of items) {
+          const id = keyFor(it.kind === 'setValue' ? 'setValue' : 'setVec2Tags', it.payload, context);
+          it.id = id;
+          enqueue(it);
+        }
+      } else if (op === 'migrate') {
+        // Best-effort: enqueue verifies for target side after migrate completes (vector entries only).
+        for (const it of (payload.items || [])) {
+          const id = `MGV:${context.card}|${context.repo}|${context.file}:${it.vec2[0]}|${it.vec2[1]}`;
+          enqueue({ id, kind: 'setValue', context: { ...context }, payload: { vec2: it.vec2, values: [] } }); // values unknown; verify presence only
+        }
+      }
+      scheduleNext();
+    } catch (e) {
+      cfg.onLog('warn', 'reliabilityRule enqueue error', op, e?.message || e);
+    }
+    // No replacement/abort; we only observe and ensure after-the-fact.
+    return undefined;
+  }
+
+  return { rule: reliabilityRule, worker, queueIntrospect: () => worker.snapshot() };
+}

--- a/vec2BucketManager.js
+++ b/vec2BucketManager.js
@@ -1,0 +1,282 @@
+// vec2BucketManager.js
+// A drop-in “manager” that encapsulates the full functionality you exercised in index.html,
+// exposing a clean, UI-free API for apps/tests/workers.
+//
+// Dependencies (place alongside this file):
+//   - bucketOrchestrator.js
+//   - vec2StorageManager.js
+//   - myEdgeCaseLibrary.js
+//   - reliabilityEdgeRule.js
+//
+// Usage (ESM):
+//   import Vec2BucketManager from './vec2BucketManager.js';
+//   const mgr = await Vec2BucketManager.create({
+//     context: { card:'c001', repo:'0xb1', file:'0xf1', group:'chem' },
+//     rules:   { shard:{enabled:true,sizeX:256,sizeY:256}, throttleMs:60 },
+//     reliability: { tickMs:150, maxAttempts:10 },
+//   });
+//   await mgr.setValue([10,20], [1,2,3], { group:'chem' });
+//   const withNames = await mgr.getValueWithNames([10,20], { group:'chem' });
+//
+// Notes:
+//   - Buckets are ALWAYS sanitized/lowercased by resolver here.
+//   - Rule packs can be replaced at runtime (hard throttle preserved by default).
+//   - Reliability worker (verify+heal queue) can be started/stopped on demand.
+//   - All orchestrator public methods are surfaced 1:1 with optional contextOverride.
+
+import BucketOrchestrator from './bucketOrchestrator.js';
+import buildRules, { defaultEdgeOptions as _edgeDefaults } from './myEdgeCaseLibrary.js';
+import installReliability from './reliabilityEdgeRule.js';
+
+// ---------- defaults ----------
+const defaultResolver = (ctx) => {
+  const base = (ctx.baseBucket && String(ctx.baseBucket)) ||
+               (`${ctx.card}${ctx.repo}${ctx.file}statecapture`);
+  const suffix = ctx.routeSuffix ? String(ctx.routeSuffix) : '';
+  return (base + suffix).toLowerCase().replace(/[^a-z0-9-]/g, '');
+};
+
+const defaultManagerOptions = {
+  dbName: 'Vec2DB',
+  dbVersion: 1,
+  context: { card: 'c001', repo: '0xb1', file: '0xf1', group: 'default' },
+  resolver: defaultResolver,
+  // myEdgeCaseLibrary options (hard throttle behavior kept)
+  rules: {
+    contextDefaults: _edgeDefaults.contextDefaults,
+    shard: { enabled: true, sizeX: 256, sizeY: 256 },
+    timeSlicing: { enabled: false, timeSliceOps: new Set(['bulkPreserve']) },
+    throttleMs: 60,
+    maxValuesPerWrite: 8192,
+    maxBulkEntries: 5000,
+    aliasMap: { work: (ctx) => `${ctx.card}${ctx.repo}${ctx.file}statecapture` },
+  },
+  reliability: {
+    enabled: true,
+    tickMs: 150,
+    maxAttempts: 10,
+    onLog: null, // (level,...args)=>void
+  },
+  onLog: null, // (level,...args)=>void
+};
+
+// ---------- helper ----------
+function noop() {}
+function makeLogger(cb) {
+  return typeof cb === 'function' ? cb : noop;
+}
+
+function cloneTimeSliceOps(value, fallback) {
+  const source = value ?? fallback;
+  if (source instanceof Set) return new Set(source);
+  if (Array.isArray(source)) return new Set(source);
+  return source ?? new Set();
+}
+
+function normalizeRules(base, overrides = {}) {
+  const merged = { ...base, ...(overrides || {}) };
+  merged.shard = { ...base.shard, ...(overrides.shard || {}) };
+  merged.timeSlicing = { ...base.timeSlicing, ...(overrides.timeSlicing || {}) };
+  merged.timeSlicing.timeSliceOps = cloneTimeSliceOps(
+    overrides.timeSlicing?.timeSliceOps,
+    base.timeSlicing?.timeSliceOps
+  );
+  return merged;
+}
+
+function normalizeManagerOptions(opts = {}) {
+  const rulesOverrides = opts.rules || {};
+  const reliabilityOverrides = opts.reliability || {};
+  const merged = {
+    ...defaultManagerOptions,
+    ...opts,
+    context: { ...defaultManagerOptions.context, ...(opts.context || {}) },
+    resolver: typeof opts.resolver === 'function' ? opts.resolver : defaultManagerOptions.resolver,
+    rules: normalizeRules(defaultManagerOptions.rules, rulesOverrides),
+    reliability: {
+      ...defaultManagerOptions.reliability,
+      ...reliabilityOverrides,
+    },
+  };
+
+  if (typeof merged.reliability.onLog !== 'function') {
+    merged.reliability.onLog = defaultManagerOptions.reliability.onLog;
+  }
+  merged.onLog = typeof opts.onLog === 'function' ? opts.onLog : defaultManagerOptions.onLog;
+  return merged;
+}
+
+// ---------- manager ----------
+export default class Vec2BucketManager {
+  /**
+   * Factory that constructs, init()s, and returns a ready manager.
+   * @param {Partial<typeof defaultManagerOptions>} opts
+   */
+  static async create(opts = {}) {
+    const mgr = new Vec2BucketManager(opts);
+    await mgr.init(opts.context);
+    // Apply initial default pack and reliability (if enabled)
+    await mgr.applyRules(opts.rules);
+    if (mgr._reliability?.worker && opts?.reliability?.enabled !== false) {
+      mgr._reliability.worker.start();
+    }
+    return mgr;
+  }
+
+  constructor(opts = {}) {
+    this.options = normalizeManagerOptions(opts);
+    // wire logs
+    this._log = makeLogger(this.options.onLog);
+    // base orchestrator
+    this._orch = new BucketOrchestrator({
+      bucketNameResolver: this.options.resolver || defaultResolver,
+      dbName: this.options.dbName,
+      dbVersion: this.options.dbVersion,
+      onLog: (lvl, ...args) => this._log(`orch:${lvl}`, ...args),
+    });
+    // reliability is installed on-demand in applyRules()
+    this._reliability = null;
+  }
+
+  /** Initialize base storage context */
+  async init(context = this.options.context) {
+    this._baseContext = { ...this.options.context, ...context };
+    await this._orch.init(this._baseContext);
+    this._log('mgr:info', 'initialized', JSON.stringify(this._baseContext));
+  }
+
+  /**
+   * Replace the rule pack with new options (clears previously registered rules),
+   * then re-attaches the reliability rule if it was installed.
+   * @param {object} ruleOptions
+   */
+  async applyRules(ruleOptions = {}) {
+    // clear current rules (default pack + customs)
+    if (Array.isArray(this._orch._rules)) this._orch._rules.length = 0;
+
+    // merge with last-used or defaults
+    this.options.rules = normalizeRules(this.options.rules, ruleOptions || {});
+    const pack = buildRules(this.options.rules);
+    this._orch.registerRule(pack);
+
+    // (Re)install reliability layer if requested
+    const relCfg = this.options.reliability || {};
+    if (relCfg && relCfg.enabled !== false) {
+      // If already installed, keep the same worker instance but re-attach rule
+      if (!this._reliability) {
+        this._reliability = installReliability(this._orch, {
+          ...relCfg,
+          onLog: (lvl, ...m) => (relCfg.onLog ? relCfg.onLog(lvl, ...m) : this._log(`reliability:${lvl}`, ...m)),
+        });
+      }
+      this._orch.registerRule(this._reliability.rule);
+    }
+
+    this._log('mgr:info', 'rules applied', {
+      throttleMs: this.options.rules.throttleMs,
+      shard: this.options.rules.shard,
+      timeSlicing: !!this.options.rules.timeSlicing?.enabled,
+    });
+  }
+
+  /** Start/stop reliability worker explicitly */
+  startReliability() { this._reliability?.worker?.start?.(); }
+  stopReliability()  { this._reliability?.worker?.stop?.(); }
+  reliabilityQueueSize() { return this._reliability?.worker?.size?.() ?? 0; }
+  reliabilitySnapshot()  { return this._reliability?.queueIntrospect?.() ?? []; }
+
+  /** Swap resolver at runtime (e.g., blue/green cutover) */
+  setResolver(fn) {
+    const resolver = typeof fn === 'function' ? fn : defaultResolver;
+    this.options.resolver = resolver;
+    this._orch.resolveBucket = resolver;
+    this._log('mgr:info', 'resolver updated');
+  }
+
+  /** Update base DB options (re-creates internal orchestrator). Call BEFORE heavy use. */
+  reconfigureDB({ dbName, dbVersion } = {}) {
+    if (dbName) this.options.dbName = dbName;
+    if (dbVersion) this.options.dbVersion = dbVersion;
+    // rebuild orchestrator with same context and rules
+    const prevRel = this._reliability;
+    this._orch = new BucketOrchestrator({
+      bucketNameResolver: this.options.resolver || defaultResolver,
+      dbName: this.options.dbName,
+      dbVersion: this.options.dbVersion,
+      onLog: (lvl, ...args) => this._log(`orch:${lvl}`, ...args),
+    });
+    // re-init + re-apply rules + re-attach reliability
+    return this.init(this._baseContext).then(() => this.applyRules(this.options.rules)).then(() => {
+      if (prevRel?.worker && this.options.reliability?.enabled !== false) {
+        // reliability was already installed and running; start it again
+        this._reliability?.worker?.start?.();
+      }
+    });
+  }
+
+  /** Replace/merge base context; affects subsequent calls (unless contextOverride provided per call) */
+  setBaseContext(ctx = {}) {
+    this._baseContext = { ...this._baseContext, ...ctx };
+    this._log('mgr:info', 'base context updated', JSON.stringify(this._baseContext));
+  }
+
+  /** Clear orchestrator caches (does not delete data) */
+  resetCache() { this._orch.resetCache(); }
+
+  // ------------------- PUBLIC API (thin wrappers) -------------------
+
+  // value ops
+  async setValue(vec2, values, opts = {}) {
+    return this._orch.setValue(vec2, values, this._withCtx(opts));
+  }
+  async getValue(vec2, opts = {}) {
+    return this._orch.getValue(vec2, this._withCtx(opts));
+  }
+  async getValueWithNames(vec2, opts = {}) {
+    return this._orch.getValueWithNames(vec2, this._withCtx(opts));
+  }
+  async updateValue(vec2, index, value, opts = {}) {
+    return this._orch.updateValue(vec2, index, value, this._withCtx(opts));
+  }
+  async deleteValue(vec2, opts = {}) {
+    return this._orch.deleteValue(vec2, this._withCtx(opts));
+  }
+
+  // tag ops
+  async setVec2Tags(group, vec2, names, opts = {}) {
+    return this._orch.setVec2Tags(group, vec2, names, this._withCtx(opts));
+  }
+  async setVec2TagName(group, vec2, index, name, opts = {}) {
+    return this._orch.setVec2TagName(group, vec2, index, name, this._withCtx(opts));
+  }
+  async getVec2Tags(group, vec2, opts = {}) {
+    return this._orch.getVec2Tags(group, vec2, this._withCtx(opts));
+  }
+  async deleteVec2Tags(group, vec2, opts = {}) {
+    return this._orch.deleteVec2Tags(group, vec2, this._withCtx(opts));
+  }
+
+  // bulk & migration
+  async bulkPreserve(entries, opts = {}) {
+    return this._orch.bulkPreserve(entries, this._withCtx(opts));
+  }
+  async migrate({ fromContext, toContext, items }) {
+    return this._orch.migrate({ fromContext, toContext, items });
+  }
+
+  // rule management (advanced)
+  /** Register a custom rule (called AFTER the default pack & reliability). */
+  registerRule(ruleFn) {
+    this._orch.registerRule(ruleFn);
+    this._log('mgr:info', 'custom rule registered');
+  }
+
+  // -------------- internals --------------
+  _withCtx(opts) {
+    const { contextOverride, ...rest } = opts || {};
+    return {
+      ...rest,
+      contextOverride: contextOverride ? { ...this._baseContext, ...contextOverride } : this._baseContext
+    };
+  }
+}

--- a/vec2StorageManager.js
+++ b/vec2StorageManager.js
@@ -1,0 +1,341 @@
+// vec2StorageManager.js
+// Standalone module for a Storage Bucket + IndexedDB where:
+//   • Data store "vec2Data": key = "<x>|<y>", value = { key, values: Float64Array }
+//   • Tag store  "vec2Tags": key = "<group>|<x>|<y>", value = { key, names: string[] }
+// Requirements:
+//   • Bucket name is forced to lowercase.
+//   • Storage Buckets API used if available; otherwise falls back to global indexedDB.
+
+export default class Vec2StorageManager {
+  /**
+   * @param {string} bucketName  Storage Bucket name (will be lowercased).
+   * @param {object} options
+   *   options.dbName     : string (default "Vec2DB")
+   *   options.dbVersion  : number (default 1)
+   *   options.dataStore  : string (default "vec2Data")
+   *   options.tagStore   : string (default "vec2Tags")
+   */
+  constructor(bucketName, options = {}) {
+    this.bucketName  = (bucketName || 'vec2bucket').toLowerCase();
+    this.dbName      = options.dbName ?? 'Vec2DB';
+    this.dbVersion   = options.dbVersion ?? 1;
+    this.dataStore   = options.dataStore ?? 'vec2Data';
+    this.tagStore    = options.tagStore ?? 'vec2Tags';
+
+    this.bucket = null;
+    this.idb    = null; // Reference to proper indexedDB (bucket.indexedDB or window.indexedDB)
+    this._openDBPromise = null;
+  }
+
+  // ---------- Bucket & DB bootstrap ----------
+
+  async init() {
+    this.bucket = await this._openBucket(this.bucketName);
+    this.idb    = this.bucket?.indexedDB ?? window.indexedDB;
+
+    // One-shot open/upgrade
+    await this._openDB();
+  }
+
+  async _openBucket(name) {
+    if (!('storageBuckets' in navigator)) {
+      // Fallback, still usable with window.indexedDB
+      return null;
+    }
+    // Cache buckets on window
+    window.openBuckets = window.openBuckets || new Map();
+    if (window.openBuckets.has(name)) return window.openBuckets.get(name);
+    const bucket = await navigator.storageBuckets.open(name);
+    window.openBuckets.set(name, bucket);
+    return bucket;
+  }
+
+  async _openDB() {
+    if (this._openDBPromise) return this._openDBPromise;
+    this._openDBPromise = new Promise((resolve, reject) => {
+      const req = this.idb.open(this.dbName, this.dbVersion);
+      req.onupgradeneeded = (e) => {
+        const db = e.target.result;
+        if (!db.objectStoreNames.contains(this.dataStore)) {
+          db.createObjectStore(this.dataStore, { keyPath: 'key' });
+        }
+        if (!db.objectStoreNames.contains(this.tagStore)) {
+          db.createObjectStore(this.tagStore, { keyPath: 'key' });
+        }
+      };
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(new Error(`Failed to open ${this.dbName}: ${req.error}`));
+    });
+    return this._openDBPromise;
+  }
+
+  // ---------- Key helpers (order-preserving) ----------
+
+  // Data key: "<x>|<y>"
+  _k(vec2) {
+    if (!Array.isArray(vec2) || vec2.length !== 2) throw new Error('vec2 must be [x, y]');
+    const [x, y] = vec2;
+    return `${x}|${y}`;
+  }
+
+  // Tag key: "<group>|<x>|<y>"
+  _tk(group, vec2) {
+    if (typeof group !== 'string' || !group.length) throw new Error('group must be a non-empty string');
+    return `${group}|${this._k(vec2)}`;
+  }
+
+  // ---------- Low-level transaction helpers ----------
+
+  _tx(storeNames, mode = 'readonly') {
+    return new Promise((resolve, reject) => {
+      const openReq = this.idb.open(this.dbName, this.dbVersion);
+      openReq.onsuccess = () => {
+        const db = openReq.result;
+        const tx = db.transaction(storeNames, mode);
+        resolve({ db, tx });
+      };
+      openReq.onerror = () => reject(new Error(`Failed to open ${this.dbName}: ${openReq.error}`));
+    });
+  }
+
+  // ---------- Data CRUD ----------
+
+  /**
+   * Stores float values at a vec2 key.
+   * @param {number[]} vec2      [x, y]
+   * @param {number[]|Float32Array|Float64Array} values
+   */
+  async setValue(vec2, values) {
+    await this._openDB();
+    const key = this._k(vec2);
+    // Persist as plain array, reconstruct to Float64Array on get.
+    const payload = { key, values: Array.from(values, v => Number(v)) };
+
+    const { db, tx } = await this._tx([this.dataStore], 'readwrite');
+    await new Promise((res, rej) => {
+      const store = tx.objectStore(this.dataStore);
+      const r = store.put(payload);
+      r.onsuccess = () => res();
+      r.onerror = () => rej(new Error(`setValue failed: ${r.error}`));
+    });
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => { db.close(); res(); };
+      tx.onerror = () => rej(new Error(`Transaction error: ${tx.error}`));
+    });
+    return true;
+  }
+
+  /**
+   * Gets float array for vec2 key, reconstructed as Float64Array.
+   * @param {number[]} vec2  [x, y]
+   * @returns {Promise<Float64Array|null>}
+   */
+  async getValue(vec2) {
+    await this._openDB();
+    const key = this._k(vec2);
+
+    const { db, tx } = await this._tx([this.dataStore], 'readonly');
+    const out = await new Promise((res, rej) => {
+      const store = tx.objectStore(this.dataStore);
+      const r = store.get(key);
+      r.onsuccess = () => {
+        const row = r.result;
+        if (!row) return res(null);
+        const arr = Array.isArray(row.values) ? row.values : [];
+        res(new Float64Array(arr));
+      };
+      r.onerror = () => rej(new Error(`getValue failed: ${r.error}`));
+    });
+    db.close();
+    return out;
+  }
+
+  /**
+   * Updates one index in the float array at vec2 (grows array if needed).
+   */
+  async updateValue(vec2, index, value) {
+    const current = (await this.getValue(vec2)) ?? new Float64Array([]);
+    const newLen = Math.max(current.length, index + 1);
+    const next = new Float64Array(newLen);
+    next.set(current);
+    next[index] = Number(value);
+    return this.setValue(vec2, next);
+  }
+
+  /**
+   * Deletes a vec2 record.
+   */
+  async deleteValue(vec2) {
+    await this._openDB();
+    const key = this._k(vec2);
+
+    const { db, tx } = await this._tx([this.dataStore], 'readwrite');
+    await new Promise((res, rej) => {
+      const store = tx.objectStore(this.dataStore);
+      const r = store.delete(key);
+      r.onsuccess = () => res();
+      r.onerror = () => rej(new Error(`deleteValue failed: ${r.error}`));
+    });
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => { db.close(); res(); };
+      tx.onerror = () => rej(new Error(`Transaction error: ${tx.error}`));
+    });
+    return true;
+  }
+
+  // ---------- Tag APIs (multiple names per vec2 tag set) ----------
+
+  /**
+   * Sets the full name array for a tag group at vec2.
+   * @param {string} group
+   * @param {number[]} vec2
+   * @param {string[]} names  // multiple names allowed
+   */
+  async setVec2Tags(group, vec2, names) {
+    await this._openDB();
+    const key = this._tk(group, vec2);
+    const clean = Array.from(names ?? [], n => (n == null ? '' : String(n)));
+
+    const { db, tx } = await this._tx([this.tagStore], 'readwrite');
+    await new Promise((res, rej) => {
+      const store = tx.objectStore(this.tagStore);
+      const r = store.put({ key, names: clean });
+      r.onsuccess = () => res();
+      r.onerror = () => rej(new Error(`setVec2Tags failed: ${r.error}`));
+    });
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => { db.close(); res(); };
+      tx.onerror = () => rej(new Error(`Transaction error: ${tx.error}`));
+    });
+    return true;
+  }
+
+  /**
+   * Adds or updates a single tag name at index for a tag group at vec2.
+   * Auto-expands the name array.
+   */
+  async setVec2TagName(group, vec2, index, name) {
+    const record = (await this.getVec2Tags(group, vec2)) ?? [];
+    const nextLen = Math.max(record.length, index + 1);
+    const next = new Array(nextLen).fill('');
+    for (let i = 0; i < record.length; i++) next[i] = record[i] ?? '';
+    next[index] = String(name ?? '');
+    return this.setVec2Tags(group, vec2, next);
+  }
+
+  /**
+   * Gets the name array for a tag group at vec2 (string[] or null).
+   */
+  async getVec2Tags(group, vec2) {
+    await this._openDB();
+    const key = this._tk(group, vec2);
+
+    const { db, tx } = await this._tx([this.tagStore], 'readonly');
+    const out = await new Promise((res, rej) => {
+      const store = tx.objectStore(this.tagStore);
+      const r = store.get(key);
+      r.onsuccess = () => res(r.result ? (Array.isArray(r.result.names) ? r.result.names : []) : null);
+      r.onerror = () => rej(new Error(`getVec2Tags failed: ${r.error}`));
+    });
+    db.close();
+    return out;
+  }
+
+  /**
+   * Deletes the tag array for a tag group at vec2.
+   */
+  async deleteVec2Tags(group, vec2) {
+    await this._openDB();
+    const key = this._tk(group, vec2);
+
+    const { db, tx } = await this._tx([this.tagStore], 'readwrite');
+    await new Promise((res, rej) => {
+      const store = tx.objectStore(this.tagStore);
+      const r = store.delete(key);
+      r.onsuccess = () => res();
+      r.onerror = () => rej(new Error(`deleteVec2Tags failed: ${r.error}`));
+    });
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => { db.close(); res(); };
+      tx.onerror = () => rej(new Error(`Transaction error: ${tx.error}`));
+    });
+    return true;
+  }
+
+  // ---------- Joined read ----------
+
+  /**
+   * Gets data for vec2 and aligns with names from a given tag group.
+   * If names are missing or shorter, unnamed positions are filled with "(unnamed)".
+   * @returns {Promise<{vec2:number[], values:Float64Array, names:string[]}|null>}
+   */
+  async getValueWithNames(vec2, group) {
+    const values = await this.getValue(vec2);
+    if (!values) return null;
+
+    const names = (group ? await this.getVec2Tags(group, vec2) : null) ?? [];
+    const outNames = Array.from({ length: values.length }, (_, i) => names[i] ?? '(unnamed)');
+
+    return { vec2: [vec2[0], vec2[1]], values, names: outNames };
+  }
+
+  // ---------- BULK PRESERVATION ----------
+
+  /**
+   * Bulk write for many vec2 entries and optional tag sets in ONE transaction.
+   * @param {Array<{
+   *   vec2: [number,number],
+   *   values: number[]|Float32Array|Float64Array,
+   *   tagGroup?: string,
+   *   tagNames?: string[]
+   * }>} entries
+   * @returns {Promise<{written:number, tagged:number}>}
+   */
+  async bulkPreserve(entries) {
+    await this._openDB();
+    if (!Array.isArray(entries) || !entries.length) return { written: 0, tagged: 0 };
+
+    const { db, tx } = await this._tx([this.dataStore, this.tagStore], 'readwrite');
+    const dataStore = tx.objectStore(this.dataStore);
+    const tagStore  = tx.objectStore(this.tagStore);
+
+    let written = 0, tagged = 0;
+
+    await new Promise((resolve, reject) => {
+      let pending = 0, failed = false;
+
+      const done = () => {
+        if (failed) return;
+        if (pending === 0) resolve();
+      };
+
+      for (const e of entries) {
+        const key = this._k(e.vec2);
+        const payload = { key, values: Array.from(e.values ?? [], v => Number(v)) };
+
+        pending++;
+        const pr = dataStore.put(payload);
+        pr.onsuccess = () => { written++; if (--pending === 0) done(); };
+        pr.onerror   = () => { failed = true; reject(new Error(`bulkPreserve data put failed: ${pr.error}`)); };
+
+        if (e.tagGroup && e.tagNames) {
+          const tKey = this._tk(e.tagGroup, e.vec2);
+          pending++;
+          const tr = tagStore.put({ key: tKey, names: Array.from(e.tagNames, s => String(s ?? '')) });
+          tr.onsuccess = () => { tagged++; if (--pending === 0) done(); };
+          tr.onerror   = () => { failed = true; reject(new Error(`bulkPreserve tag put failed: ${tr.error}`)); };
+        }
+      }
+
+      // Edge case: if no puts were scheduled (shouldn’t happen given entries.length), resolve.
+      if (pending === 0) resolve();
+    });
+
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => { db.close(); res(); };
+      tx.onerror    = () => rej(new Error(`Transaction error: ${tx.error}`));
+    });
+
+    return { written, tagged };
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable bucket orchestrator, rule pack, and reliability queue for vec2 Storage Bucket access
- provide a high-level Vec2BucketManager wrapper to simplify configuration and logging
- integrate the orchestrator with SDFGrid persistence to mirror cell data into contextual buckets with cleanup of stale entries

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb5fca144c832d856aeee00165d736