### PR TITLE
Implement dense zero templates with quadrant defaults

### DIFF
--- a/SDFGridLayers.js
+++ b/SDFGridLayers.js
@@ -1,7 +1,7 @@
 import { DENSE_W, DENSE_H, STORE_BASE, STORE_BASEZ, STORE_LAYER, STORE_LMETA, DEFAULT_QUADRANT_COUNT } from './SDFGridConstants.js';
 import { arraysEqual } from './SDFGridUtil.js';
 import { idbGet, idbPut } from './SDFGridStorage.js';
-import { createSparseQuadrants, denseFromQuadrants } from './SDFGridQuadrants.js';
+import { createDenseZeroTemplate } from './SDFGridQuadrants.js';
 
 function _quadrantLayout(count){
   const cols=Math.ceil(Math.sqrt(count));
@@ -66,13 +66,23 @@ function _markDirty(ctx, z, bx, by){
   set.add(qi);
 }
 
+function _isDenseTemplateCompatible(tmpl, schema, count){
+  if (!tmpl || !Array.isArray(tmpl.quadrants)) return false;
+  if (tmpl.count !== undefined && tmpl.count !== count) return false;
+  if (tmpl.fields && !arraysEqual(tmpl.fields, schema.fieldNames)) return false;
+  if (!tmpl.quadrants.length && count===0) return true;
+  return tmpl.quadrants.every(q=>ArrayBuffer.isView(q));
+}
+
 export async function _ensureZeroTemplate(){
   const count = this.quadrantCount || DEFAULT_QUADRANT_COUNT;
-  if (!this._db) return createSparseQuadrants(count, this.envExpressions || []);
+  const envExprs = this.envExpressions || [];
+  if (!this._db) return createDenseZeroTemplate(count, this.schema, envExprs);
   const key=`sid:${this.schema.id}`;
   let tmpl=await idbGet(this._db, STORE_BASEZ, key);
-  if (!tmpl){
-    tmpl=createSparseQuadrants(count, this.envExpressions || []);
+  if (!_isDenseTemplateCompatible(tmpl, this.schema, count)){
+    const existing = Array.isArray(tmpl?.quadrants) && !tmpl.quadrants.some(q=>ArrayBuffer.isView(q)) ? tmpl : null;
+    tmpl=createDenseZeroTemplate(count, this.schema, envExprs, existing);
     await idbPut(this._db, STORE_BASEZ, key, tmpl);
   }
   return tmpl;
@@ -124,8 +134,22 @@ export async function _ensureDenseLayer(z){
   const qCount=this.quadrantCount || DEFAULT_QUADRANT_COUNT;
   _ensureLayout(this);
 
+  const zeroTemplate = await this._ensureZeroTemplate();
+  const zeroQuads = zeroTemplate?.quadrants || [];
+  const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+
+  if (Fnew){
+    const maxZero=Math.min(zeroQuads.length, qCount);
+    for (let i=0;i<maxZero;i++){
+      const quad=zeroQuads[i];
+      if (ArrayBuffer.isView(quad) && quad.length){
+        _insertQuadrant.call(this, arr, i, quad, Fnew);
+      }
+    }
+  }
+
   if (!this._db){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+    await this._applySparseIntoDense(z, arr);
     this._layerCache.set(key,arr); return arr;
   }
 
@@ -133,8 +157,6 @@ export async function _ensureDenseLayer(z){
   const buffers=await Promise.all(Array.from({length:qCount},(_,i)=>idbGet(this._db, STORE_LAYER, `${key},${i}`)));
 
   if (buffers.every(b=>!b)){
-    const tmpl=await this._ensureZeroTemplate();
-    const arr=denseFromQuadrants(tmpl, targetSchema);
     await this._applySparseIntoDense(z, arr);
     await Promise.all(Array.from({length:qCount},(_,i)=>{
       const quad=_sliceQuadrant.call(this, arr, i, Fnew);
@@ -147,17 +169,28 @@ export async function _ensureDenseLayer(z){
   const curSid=lmeta?.sid|0;
   const curList=lmeta?.fields || [];
   if (curSid === targetSchema.id && arraysEqual(curList, targetSchema.fieldNames)){
-    const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
+    const missing=[];
     for(let i=0;i<qCount;i++){
-      const buf=buffers[i]; if(!buf) continue;
-      _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
+      const buf=buffers[i];
+      if(buf){
+        _insertQuadrant.call(this, arr, i, new Float32Array(buf), Fnew);
+      } else if (ArrayBuffer.isView(zeroQuads[i]) && zeroQuads[i].length){
+        missing.push(i);
+      }
+    }
+    await this._applySparseIntoDense(z, arr);
+    if (missing.length){
+      await Promise.all(missing.map(i=>{
+        const quad=_sliceQuadrant.call(this, arr, i, Fnew);
+        return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);
+      }));
+      await idbPut(this._db, STORE_LMETA, key, { sid:targetSchema.id, fields:targetSchema.fieldNames });
     }
     this._layerCache.set(key,arr); return arr;
   }
 
   const Fold=curList.length;
   const oldIdx=new Map(curList.map((n,i)=>[n,i]));
-  const arr=new Float32Array(DENSE_W*DENSE_H*Fnew);
 
   for(let qi=0; qi<qCount; qi++){
     const buf=buffers[qi]; if(!buf) continue;
@@ -183,6 +216,7 @@ export async function _ensureDenseLayer(z){
     }
   }
 
+  await this._applySparseIntoDense(z, arr);
   await Promise.all(Array.from({length:qCount},(_,i)=>{
     const quad=_sliceQuadrant.call(this, arr, i, Fnew);
     return idbPut(this._db, STORE_LAYER, `${key},${i}`, quad.buffer);

--- a/SDFGridQuadrants.js
+++ b/SDFGridQuadrants.js
@@ -15,38 +15,77 @@ export function quantizePareto(env){
   return out;
 }
 
-// Create sparse quadrants from serialized environment expressions
-// Each expression resolves to an object whose keys become the quadrant variables
-// with zero as the default value. Expressions can differ per quadrant.
-export function createSparseQuadrants(count = DEFAULT_QUADRANT_COUNT, envExprs = []){
-  const quads = [];
-  for (let i=0; i<count; i++){
-    const expr = envExprs[i] ?? envExprs[0] ?? {};
-    const tmpl = parseEnvExpression(expr);
-    const q = {};
-    for (const k of Object.keys(tmpl)) q[k] = 0;
-    quads.push(q);
+export function quadrantLayout(count = DEFAULT_QUADRANT_COUNT){
+  const safeCount = Math.max(1, Number.isFinite(count) ? count|0 : DEFAULT_QUADRANT_COUNT);
+  const cols = Math.ceil(Math.sqrt(safeCount));
+  const rows = Math.ceil(safeCount / cols);
+  const qW = Math.ceil(DENSE_W / cols);
+  const qH = Math.ceil(DENSE_H / rows);
+  return { cols, rows, qW, qH };
+}
+
+function _coerceDefault(val){
+  if (typeof val === 'number') return Number.isFinite(val) ? val : 0;
+  const num = Number(val);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function _defaultsForQuadrant(index, envExprs, fallback){
+  if (fallback && typeof fallback === 'object' && !ArrayBuffer.isView(fallback)) return fallback;
+  const expr = envExprs[index] ?? envExprs[0] ?? {};
+  return parseEnvExpression(expr);
+}
+
+// Create a dense zero template per quadrant from serialized environment expressions.
+// Each quadrant is represented as a Float32Array sized to the quadrant footprint, where
+// every cell is initialized to the default environment value for the associated field.
+export function createDenseZeroTemplate(count = DEFAULT_QUADRANT_COUNT, schema = { fieldNames: [] }, envExprs = [], existing = null){
+  const qCount = Math.max(0, Number.isFinite(count) ? count|0 : DEFAULT_QUADRANT_COUNT);
+  const fields = Array.isArray(schema?.fieldNames) ? schema.fieldNames.slice() : [];
+  const F = fields.length;
+  const layout = quadrantLayout(qCount || 1);
+  const quadrants = [];
+
+  for (let i=0; i<qCount; i++){
+    const defaults = _defaultsForQuadrant(i, envExprs, existing?.quadrants?.[i]);
+    const col = i % layout.cols;
+    const row = Math.floor(i / layout.cols);
+    const width  = col === layout.cols - 1 ? DENSE_W - col * layout.qW : layout.qW;
+    const height = row === layout.rows - 1 ? DENSE_H - row * layout.qH : layout.qH;
+    const quad = new Float32Array(width * height * F);
+
+    if (F){
+      const cellDefaults = new Float32Array(F);
+      for (let fi=0; fi<F; fi++){
+        const name = fields[fi];
+        cellDefaults[fi] = _coerceDefault(defaults?.[name] ?? 0);
+      }
+      for (let offset=0; offset<quad.length; offset+=F){
+        quad.set(cellDefaults, offset);
+      }
+    }
+    quadrants.push(quad);
   }
-  return { quadrants: quads };
+
+  return { version: 2, fields, count: qCount, layout, quadrants };
 }
 
 // Reconstruct a dense Float32Array layer from a quadrant template
 export function denseFromQuadrants(template, schema){
   const F = schema.fieldNames.length;
   const arr = new Float32Array(DENSE_W * DENSE_H * F);
+  if (!F) return arr;
+
   const quads = template?.quadrants || [];
   const qCount = quads.length;
   if (!qCount) return arr;
 
-  // Lay out quadrants across the 1024×1024 layer in a near-square grid
-  const cols = Math.ceil(Math.sqrt(qCount));
-  const rows = Math.ceil(qCount / cols);
-  const qW = Math.ceil(DENSE_W / cols);
-  const qH = Math.ceil(DENSE_H / rows);
+  const { cols, rows, qW, qH } = quadrantLayout(qCount);
 
   for (let i=0; i<qCount; i++){
     const quad = quads[i];
-    const entries = Object.entries(quad);
+    if (!quad) continue;
+
     const col = i % cols;
     const row = Math.floor(i / cols);
     const xStart = col * qW;
@@ -54,13 +93,28 @@ export function denseFromQuadrants(template, schema){
     const xEnd = Math.min(xStart + qW, DENSE_W);
     const yEnd = Math.min(yStart + qH, DENSE_H);
 
-    for (let y=yStart; y<yEnd; y++){
-      const rowBase = y * DENSE_W * F;
-      for (let x=xStart; x<xEnd; x++){
-        const base = rowBase + x * F;
-        for (const [name, val] of entries){
-          const fi = schema.index.get(name);
-          if (fi != null) arr[base + fi] = val;
+    if (ArrayBuffer.isView(quad)){
+      const qw = xEnd - xStart;
+      const qh = yEnd - yStart;
+      let idx = 0;
+      for (let y=0; y<qh; y++){
+        const rowBase = (yStart + y) * DENSE_W * F;
+        for (let x=0; x<qw; x++){
+          const base = rowBase + (xStart + x) * F;
+          for (let fi=0; fi<F; fi++) arr[base + fi] = quad[idx++];
+        }
+      }
+    } else {
+      const entries = Object.entries(quad);
+      if (!entries.length) continue;
+      for (let y=yStart; y<yEnd; y++){
+        const rowBase = y * DENSE_W * F;
+        for (let x=xStart; x<xEnd; x++){
+          const base = rowBase + x * F;
+          for (const [name, val] of entries){
+            const fi = schema.index.get(name);
+            if (fi != null) arr[base + fi] = _coerceDefault(val);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- replace the sparse base_zero template with a dense quadrant template seeded from environment defaults
- ensure dense layer construction hydrates from the dense template, reuses stored quadrants, and persists any missing defaults

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb6d1ad924832db441c87d8ef22e7d